### PR TITLE
Adds a report button in the dropdown for player options

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -108,4 +108,32 @@ chrome.runtime.onMessage.addListener(function (message, sender, sendResponse) {
         // Send the data back to the popup
         chrome.runtime.sendMessage({ action: 'recieveNameDictPopup', data: nameDictionary });
     }
+    if(message.action === "reportUser") {
+        const reason = message.reason;
+        const username = message.reportedUser;
+        const sessionId = message.sessionId;
+        const requestBody = JSON.stringify({
+            username, reason
+        });
+        fetch('https://backend-production-c33b.up.railway.app/block_user', {
+            method: 'POST',
+            headers: {
+                'Origin': 'chrome-extension://' + extensionID,
+                'Content-Type': 'application/json'
+                },
+                body: requestBody
+            }).then(response => {
+                if (!response.ok) {
+                throw new Error(`Network response was not ok: ${response.status}`);
+                }
+                return response.json();
+            })
+            .then(data => {
+                console.log(data);
+            }
+            ).catch(error => {
+                console.error('Error reporting user:', error.message);
+            }
+            );
+    }
   });

--- a/extension/content.js
+++ b/extension/content.js
@@ -1,10 +1,23 @@
 let nameDictionary = {};
 let lastNamesOnPage = [];
 let lastCommandersOnPage = [];
+let playerDropdownButtonListeners = [];
+
+let currentReportedPlayer = null;
 
 function main() {
-
   addSpectatorButton();
+  const playerDropdownButtons = document.querySelectorAll("button.p-1.shadow-md.rounded.text-white.transition-all.ease-in-out.duration-200.bg-surface-high");
+  for(const dropdown of Array.from(playerDropdownButtons.values()).filter((dropdown) => !playerDropdownButtonListeners.includes(dropdown))) {
+    playerDropdownButtonListeners.push(dropdown);
+    dropdown.addEventListener('click', () => {
+      setTimeout(() => {
+        addReportButton();
+      }, 10);
+      currentReportedPlayer = dropdown.parentElement.parentElement.parentElement.querySelector('div.flex-1.overflow-hidden').querySelector('div.flex-1').querySelector('div.cursor-pointer.text-white.w-full.overflow-hidden').querySelector('div.flex.items-center.w-full').querySelector('div.font-bold.truncate.leading-snug.text-sm').innerHTML;
+      console.log(currentReportedPlayer)
+    })
+  }
 
   // Retrieve the player names
   const nameElements = document.querySelectorAll('.font-bold.truncate.leading-snug.text-sm');
@@ -120,6 +133,35 @@ function addSpectatorButton() {
     });
 
     targetDiv.appendChild(spectatorButton);
+  }
+}
+
+function addReportButton() {
+  const playerDropdownDiv = document.querySelectorAll('div .bg-surface-high.rounded.text-sm.shadow-lg.py-1.w-40');
+  if(playerDropdownDiv && !document.getElementById("ReportButton")) {
+    const reportButton = document.createElement('button');
+    reportButton.textContent = 'Pals Report';
+    reportButton.id = 'ReportButton';
+    reportButton.className = 'text-left w-full px-4 cursor-pointer transition-all ease-in-out duration-200 hover:bg-red-700 hover:text-white py-1 text-xs';
+    reportButton.style.color = 'red';
+    reportButton.onmouseover = () => {
+      reportButton.style.color = 'white';
+    }
+    reportButton.onmouseout = () => {
+      reportButton.style.color = 'red';
+    }
+    reportButton.addEventListener('click', () => {
+      const reason = prompt(`Please enter the reason for reporting ${currentReportedPlayer}.`);
+      if(reason !== null) {
+        chrome.runtime.sendMessage({
+          action: 'reportPlayer',
+          data: { reportedUser: currentReportedPlayer, "reason": reason, "sessionID": window.location.pathname }
+        });
+      }
+    });
+    for(const div of playerDropdownDiv) {
+      div.appendChild(reportButton);
+    }
   }
 }
 


### PR DESCRIPTION
This pull request adds a button to the dropdown hamburger menu that each player has that allows you to report them to the Spelltable Pals system and have them added to the list. It follows the conventions laid out in the code previously written and makes a POST request to the backend to update the database. Here's some screenshots showing the feature in action.
![image](https://github.com/ItsGoldeneyes/SpellTablePals/assets/10294758/7ac622ec-fe1e-47a2-bd0c-c6283a8271d8)
![image](https://github.com/ItsGoldeneyes/SpellTablePals/assets/10294758/ff154d57-a7f8-436d-8900-c31d255b6090)
