### PR TITLE
adds Discord link redirect to website

### DIFF
--- a/website/deps.ts
+++ b/website/deps.ts
@@ -1,0 +1,1 @@
+export * as tldts from "npm:tldts@6.1.11";

--- a/website/fresh.gen.ts
+++ b/website/fresh.gen.ts
@@ -4,6 +4,7 @@
 
 import * as $_404 from "./routes/_404.tsx";
 import * as $_app from "./routes/_app.tsx";
+import * as $_middleware from "./routes/_middleware.ts";
 import * as $api_joke from "./routes/api/joke.ts";
 import * as $greet_name_ from "./routes/greet/[name].tsx";
 import * as $index from "./routes/index.tsx";
@@ -14,6 +15,7 @@ const manifest = {
   routes: {
     "./routes/_404.tsx": $_404,
     "./routes/_app.tsx": $_app,
+    "./routes/_middleware.ts": $_middleware,
     "./routes/api/joke.ts": $api_joke,
     "./routes/greet/[name].tsx": $greet_name_,
     "./routes/index.tsx": $index,

--- a/website/routes/_middleware.ts
+++ b/website/routes/_middleware.ts
@@ -2,6 +2,7 @@ import { FreshContext } from "$fresh/server.ts";
 import { tldts } from "../deps.ts";
 
 const invite = "https://discord.com/invite/9QwzXz5Rt5";
+const disabled = false;
 
 export function handler(
   req: Request,
@@ -10,6 +11,12 @@ export function handler(
   const domain = tldts.parse(req.url);
   console.log(domain);
   if (domain.subdomain === "discord") {
+    if (disabled) {
+      return new Response(
+        "Our Discord is currently not taking any more invites, sorry",
+        { status: 403 },
+      );
+    }
     return Response.redirect(invite, 307);
   }
   return ctx.next();

--- a/website/routes/_middleware.ts
+++ b/website/routes/_middleware.ts
@@ -1,0 +1,16 @@
+import { FreshContext } from "$fresh/server.ts";
+import { tldts } from "../deps.ts";
+
+const invite = "https://discord.com/invite/9QwzXz5Rt5";
+
+export function handler(
+  req: Request,
+  ctx: FreshContext,
+) {
+  const domain = tldts.parse(req.url);
+  console.log(domain);
+  if (domain.subdomain === "discord") {
+    return Response.redirect(invite, 307);
+  }
+  return ctx.next();
+}

--- a/website/routes/_middleware.ts
+++ b/website/routes/_middleware.ts
@@ -4,6 +4,8 @@ import { tldts } from "../deps.ts";
 const invite = "https://discord.com/invite/9QwzXz5Rt5";
 const disabled = false;
 
+// TODO(ybabts): Integrate these controls into the database or Discord bot and move this to a separate file
+
 export function handler(
   req: Request,
   ctx: FreshContext,


### PR DESCRIPTION
This pull request adds a redirect function to the website that redirects the user to our Discord if you go to discord.spelltablepals.com. This is in response to the original method of this that we used breaking. Now we also have more control over the link and don't have to wait for propagation to fix things.