### PR TITLE
Fixes changes not showing on beta site because of it's inherit subdomain & removes console log

### DIFF
--- a/website/routes/_middleware.ts
+++ b/website/routes/_middleware.ts
@@ -11,8 +11,7 @@ export function handler(
   ctx: FreshContext,
 ) {
   const domain = tldts.parse(req.url);
-  console.log(domain);
-  if (domain.subdomain === "discord") {
+  if (domain.subdomain === "discord" || domain.subdomain === "discord.beta") {
     if (disabled) {
       return new Response(
         "Our Discord is currently not taking any more invites, sorry",


### PR DESCRIPTION
The beta site uses the prepended "beta" in "beta.spelltablepals.com" so the check for Discord didn't work because it would have been "discord.beta.spelltablepals.com" instead. Added an exception to make this work in preproduction before deploying.