### PR TITLE
Moves Discord link endpoint to use pathname instead of subdomain

### DIFF
--- a/website/deps.ts
+++ b/website/deps.ts
@@ -1,1 +1,0 @@
-export * as tldts from "npm:tldts@6.1.11";

--- a/website/middleware/discord-link.ts
+++ b/website/middleware/discord-link.ts
@@ -1,0 +1,24 @@
+import { FreshContext } from "$fresh/server.ts";
+
+const invite = "https://discord.com/invite/9QwzXz5Rt5";
+const disabled = false;
+
+// TODO(ybabts): Integrate these controls into the database or Discord bot.
+
+export function DiscordLinkMiddleware(
+  req: Request,
+  ctx: FreshContext,
+) {
+  const url = new URL(req.url);
+  const path = url.pathname;
+  if (path === "/discord") {
+    if (disabled) {
+      return new Response(
+        "Our Discord is currently not taking any more invites, sorry",
+        { status: 403 },
+      );
+    }
+    return Response.redirect(invite, 307);
+  }
+  return ctx.next();
+}

--- a/website/middleware/mod.ts
+++ b/website/middleware/mod.ts
@@ -1,0 +1,1 @@
+export { DiscordLinkMiddleware } from "./discord-link.ts";

--- a/website/routes/_middleware.ts
+++ b/website/routes/_middleware.ts
@@ -1,8 +1,7 @@
 import { FreshContext } from "$fresh/server.ts";
-import { tldts } from "../deps.ts";
 
 const invite = "https://discord.com/invite/9QwzXz5Rt5";
-const disabled = false;
+const disabled = true;
 
 // TODO(ybabts): Integrate these controls into the database or Discord bot and move this to a separate file
 
@@ -10,8 +9,9 @@ export function handler(
   req: Request,
   ctx: FreshContext,
 ) {
-  const domain = tldts.parse(req.url);
-  if (domain.subdomain === "discord" || domain.subdomain === "discord.beta") {
+  const url = new URL(req.url);
+  const path = url.pathname;
+  if (path === "/discord") {
     if (disabled) {
       return new Response(
         "Our Discord is currently not taking any more invites, sorry",

--- a/website/routes/_middleware.ts
+++ b/website/routes/_middleware.ts
@@ -1,7 +1,7 @@
 import { FreshContext } from "$fresh/server.ts";
 
 const invite = "https://discord.com/invite/9QwzXz5Rt5";
-const disabled = true;
+const disabled = false;
 
 // TODO(ybabts): Integrate these controls into the database or Discord bot and move this to a separate file
 

--- a/website/routes/_middleware.ts
+++ b/website/routes/_middleware.ts
@@ -1,24 +1,5 @@
-import { FreshContext } from "$fresh/server.ts";
+import { DiscordLinkMiddleware } from "../middleware/mod.ts";
 
-const invite = "https://discord.com/invite/9QwzXz5Rt5";
-const disabled = false;
-
-// TODO(ybabts): Integrate these controls into the database or Discord bot and move this to a separate file
-
-export function handler(
-  req: Request,
-  ctx: FreshContext,
-) {
-  const url = new URL(req.url);
-  const path = url.pathname;
-  if (path === "/discord") {
-    if (disabled) {
-      return new Response(
-        "Our Discord is currently not taking any more invites, sorry",
-        { status: 403 },
-      );
-    }
-    return Response.redirect(invite, 307);
-  }
-  return ctx.next();
-}
+export const handler = [
+  DiscordLinkMiddleware,
+];


### PR DESCRIPTION
This pull request changes the Discord link from `discord.spelltablepals.com` to `spelltablepals.com/discord`.